### PR TITLE
Get Document Custom Tabs of an Account

### DIFF
--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -3011,6 +3011,51 @@
         "x-ms-visibility": "advanced"
       }
     },
+    "/accounts/{accountId}/tab_definitions": {
+      "get": {
+        "tags": [
+          "DocuSign"
+        ],
+        "summary": "Get document custom tabs of an account",
+        "description": "Returns all the document custom tabs for a given recipient",
+        "operationId": "GetDocumentCustomTabs",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "Account id",
+            "required": true,
+            "x-ms-summary": "Account",
+            "x-ms-test-value": "insert account id",
+            "x-ms-dynamic-values": {
+              "operationId": "GetLoginAccounts",
+              "value-collection": "loginAccounts",
+              "value-path": "accountIdGuid",
+              "value-title": "name"
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DocumentCustomTabsResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true,
+        "x-ms-visibility": "advanced"
+      }
+    },
     "/accounts/{accountId}/envelopes/{envelopeId}/recipients/{recipientId}/recipientTabs": {
       "get": {
         "tags": [
@@ -4205,6 +4250,49 @@
           "description": "The id of the recipient.",
           "type": "string",
           "x-ms-summary": "Recipient Id"
+        }
+      }
+    },
+    "DocumentCustomTab": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the document custom tab.",
+          "type": "string",
+          "x-ms-summary": "Name"
+        },
+        "type": {
+          "description": "The type of the document custom tab.",
+          "type": "string",
+          "x-ms-summary": "Type"
+        },
+        "initialValue": {
+          "description": "The value of the document custom tab.",
+          "type": "string",
+          "x-ms-summary": "Intial Value"
+        },
+        "tabLabel": {
+          "description": "The label of the document custom tab.",
+          "type": "string",
+          "x-ms-summary": "Tab Label"
+        },
+        "customTabId": {
+          "description": "The document custom tab id.",
+          "type": "string",
+          "x-ms-summary": "Document Custom Tab Id"
+        }
+      }
+    },
+    "DocumentCustomTabsResponse": {
+      "type": "object",
+      "properties": {
+        "documentCustomTabs": {
+          "description": "Document custom tab",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DocumentCustomTab"
+          },
+          "x-ms-summary": "Document Custom Tab:"
         }
       }
     },

--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -3017,7 +3017,7 @@
           "DocuSign"
         ],
         "summary": "Get document custom tabs of an account",
-        "description": "Returns all the document custom tabs for a given recipient",
+        "description": "Returns all the document custom tabs for a given account",
         "operationId": "GetDocumentCustomTabs",
         "consumes": [],
         "produces": [

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1754,6 +1754,35 @@ public class Script : ScriptBase
       response.Content = new StringContent(newBody.ToString(), Encoding.UTF8, "application/json");
     }
 
+    if ("GetDocumentCustomTabs".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
+    {
+      var body = ParseContentAsJObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), false);
+      var newBody = new JObject();
+      JArray documentCustomTabs = new JArray();
+
+      foreach(JProperty tabTypes in body.Properties())
+      {
+        foreach(var tab in tabTypes.Value)
+        {
+          if (!string.IsNullOrWhiteSpace(tab["customTabId"].ToString()))
+          {
+            documentCustomTabs.Add(new JObject()
+            {
+              ["name"] = tab["name"],
+              ["type"] = tab["type"],
+              ["initialValue"] = tab["initialValue"],
+              ["tabLabel"] = tab["tabLabel"],
+              ["customTabId"] = tab["customTabId"]
+            });
+          }
+        }
+      }
+
+      newBody["documentCustomTabs"] = documentCustomTabs;
+
+      response.Content = new StringContent(newBody.ToString(), Encoding.UTF8, "application/json");
+    }
+
     if ("GetTabInfo".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
     {
       var body = ParseContentAsJObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), false);

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1779,7 +1779,6 @@ public class Script : ScriptBase
       }
 
       newBody["documentCustomTabs"] = documentCustomTabs;
-
       response.Content = new StringContent(newBody.ToString(), Encoding.UTF8, "application/json");
     }
 


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


