### PR TITLE
Flow 504: enable hybrid captive/remote recipients

### DIFF
--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -2430,6 +2430,18 @@
             "type": "string"
           },
           {
+            "name": "embeddedRecipientType",
+            "in": "query",
+            "description": "A sender-provided URL string for redirecting an embedded recipient",
+            "x-ms-summary": "Embedded recipient type",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "Hybrid captive",
+              "Remote"
+            ]
+          },
+          {
             "name": "routingOrder",
             "in": "query",
             "description": "The signing order of the recipient.",
@@ -2721,6 +2733,18 @@
               "value-path": "type",
               "value-title": "name"
             }
+          },
+          {
+            "name": "embeddedRecipientType",
+            "in": "query",
+            "description": "A sender-provided URL string for redirecting an embedded recipient",
+            "x-ms-summary": "Embedded recipient type",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "Hybrid captive",
+              "Remote"
+            ]
           },
           {
             "name": "recipientType",
@@ -4010,6 +4034,13 @@
             "required": false,
             "type": "string",
             "x-ms-summary": "signature type"
+          },
+          {
+            "name": "embeddedRecipientType",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "embedded recipient type"
           }
         ],
         "responses": {
@@ -4779,6 +4810,9 @@
           },
           "signatureType": {
             "parameter": "signatureType"
+          },
+          "embeddedRecipientType": {
+            "parameter": "embeddedRecipientType"
           }
         },
         "value-path": "Schema"

--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -2430,16 +2430,13 @@
             "type": "string"
           },
           {
-            "name": "embeddedRecipientType",
+            "name": "embeddedRecipientStartURL",
             "in": "query",
-            "description": "A sender-provided URL string for redirecting an embedded recipient",
-            "x-ms-summary": "Embedded recipient type",
+            "description": "A sender-provided URL string for redirecting an embedded recipient.",
+            "x-ms-summary": "Embedded recipient start URL",
+            "required": false,
             "x-ms-visibility": "advanced",
-            "type": "string",
-            "enum": [
-              "Hybrid captive",
-              "Remote"
-            ]
+            "type": "string"
           },
           {
             "name": "routingOrder",
@@ -2735,18 +2732,6 @@
             }
           },
           {
-            "name": "embeddedRecipientType",
-            "in": "query",
-            "description": "A sender-provided URL string for redirecting an embedded recipient",
-            "x-ms-summary": "Embedded recipient type",
-            "x-ms-visibility": "advanced",
-            "type": "string",
-            "enum": [
-              "Hybrid captive",
-              "Remote"
-            ]
-          },
-          {
             "name": "recipientType",
             "in": "query",
             "required": true,
@@ -2766,6 +2751,15 @@
             "description": "Client user ID for embedded signer",
             "required": false,
             "x-ms-summary": "Client User ID",
+            "x-ms-visibility": "advanced",
+            "type": "string"
+          },
+          {
+            "name": "embeddedRecipientStartURL",
+            "in": "query",
+            "description": "A sender-provided URL string for redirecting an embedded recipient.",
+            "x-ms-summary": "Embedded recipient start URL",
+            "required": false,
             "x-ms-visibility": "advanced",
             "type": "string"
           },
@@ -4034,13 +4028,6 @@
             "required": false,
             "type": "string",
             "x-ms-summary": "signature type"
-          },
-          {
-            "name": "embeddedRecipientType",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "x-ms-summary": "embedded recipient type"
           }
         ],
         "responses": {
@@ -4810,9 +4797,6 @@
           },
           "signatureType": {
             "parameter": "signatureType"
-          },
-          "embeddedRecipientType": {
-            "parameter": "embeddedRecipientType"
           }
         },
         "value-path": "Schema"

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1562,7 +1562,7 @@ public class Script : ScriptBase
   private void AddParamsForEmbeddedRecipientType(JArray signers, JObject body)
   {
     var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
-    var embeddedRecipientType = query.Get("embeddedRecipientType");
+    var embeddedRecipientType = query.Get("embeddedRecipientType").ToString();
 
     if (embeddedRecipientType.Equals("Hybrid captive"))
     {

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -439,7 +439,6 @@ public class Script : ScriptBase
       var query = HttpUtility.ParseQueryString(context.Request.RequestUri.Query);
       var recipientType = query.Get("recipientType");
       var signatureType = query.Get("signatureType") ?? "";
-      var embeddedRecipientType = query.Get("embeddedRecipientType") ?? "";
 
       response["name"] = "dynamicSchema";
       response["title"] = "dynamicSchema";
@@ -448,16 +447,6 @@ public class Script : ScriptBase
         ["type"] = "object",
         ["properties"] = new JObject()
       };
-
-      if(embeddedRecipientType.ToString().Equals("Hybrid captive", StringComparison.OrdinalIgnoreCase))
-      {
-        response["schema"]["properties"]["embeddedRecipientStartURL"] = new JObject
-        {
-          ["type"] = "string",
-          ["x-ms-summary"] = "* Embedded recipient start URL",
-          ["default"] = "SIGN_AT_DOCUSIGN"
-        };
-      }
 
       if (signatureType.Equals("UniversalSignaturePen_OpenTrust_Hash_TSP", StringComparison.OrdinalIgnoreCase))
       {
@@ -1254,7 +1243,7 @@ public class Script : ScriptBase
     AddCoreRecipientParams(signers, body);
     AddParamsForSelectedRecipientType(signers, body);
 
-    if (!string.IsNullOrEmpty(query.Get("embeddedRecipientType")))
+    if (!string.IsNullOrEmpty(query.Get("embeddedRecipientStartURL")))
     {
       AddParamsForEmbeddedRecipientType(signers, body);
     }
@@ -1562,12 +1551,9 @@ public class Script : ScriptBase
   private void AddParamsForEmbeddedRecipientType(JArray signers, JObject body)
   {
     var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
-    var embeddedRecipientType = query.Get("embeddedRecipientType").ToString();
+    var embeddedRecipientType = query.Get("embeddedRecipientStartURL").ToString();
 
-    if (embeddedRecipientType.Equals("Hybrid captive"))
-    {
-      signers[0]["embeddedRecipientStartURL"] = body["embeddedRecipientStartURL"];
-    }
+    signers[0]["embeddedRecipientStartURL"] = embeddedRecipientType;
   }
 
   private void AddParamsForSelectedSignatureType(JArray signers, JObject body)

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -459,16 +459,6 @@ public class Script : ScriptBase
         };
       }
 
-      if(embeddedRecipientType.Equals("Remote", StringComparison.OrdinalIgnoreCase))
-      {
-        response["schema"]["properties"]["embeddedRecipientStartURL"] = new JObject
-        {
-          ["type"] = "string",
-          ["x-ms-summary"] = "* Embedded recipient start URL",
-          ["description"] = "Embedded recipient start URL",
-        };
-      }
-
       if (signatureType.Equals("UniversalSignaturePen_OpenTrust_Hash_TSP", StringComparison.OrdinalIgnoreCase))
       {
         response["schema"]["properties"]["aesMethod"] = new JObject
@@ -1574,7 +1564,7 @@ public class Script : ScriptBase
     var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
     var embeddedRecipientType = query.Get("embeddedRecipientType");
 
-    if (embeddedRecipientType.Equals("remote"))
+    if (embeddedRecipientType.Equals("Hybrid captive"))
     {
       signers[0]["embeddedRecipientStartURL"] = body["embeddedRecipientStartURL"];
     }

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -449,7 +449,7 @@ public class Script : ScriptBase
         ["properties"] = new JObject()
       };
 
-      if(embeddedRecipientType.Equals("Hybrid captive", StringComparison.OrdinalIgnoreCase))
+      if(embeddedRecipientType.ToString().Equals("Hybrid captive", StringComparison.OrdinalIgnoreCase))
       {
         response["schema"]["properties"]["embeddedRecipientStartURL"] = new JObject
         {

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1245,7 +1245,7 @@ public class Script : ScriptBase
 
     if (!string.IsNullOrEmpty(query.Get("embeddedRecipientStartURL")))
     {
-      AddParamsForEmbeddedRecipientType(signers, body);
+      signers[0]["embeddedRecipientStartURL"] = query.Get("embeddedRecipientStartURL").ToString();
     }
 
     if (!string.IsNullOrEmpty(query.Get("signatureType")))
@@ -1546,14 +1546,6 @@ public class Script : ScriptBase
       signers[0]["name"] = body["name"];
       signers[0]["email"] = body["email"];
     }
-  }
-
-  private void AddParamsForEmbeddedRecipientType(JArray signers, JObject body)
-  {
-    var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
-    var embeddedRecipientType = query.Get("embeddedRecipientStartURL").ToString();
-
-    signers[0]["embeddedRecipientStartURL"] = embeddedRecipientType;
   }
 
   private void AddParamsForSelectedSignatureType(JArray signers, JObject body)

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -439,6 +439,7 @@ public class Script : ScriptBase
       var query = HttpUtility.ParseQueryString(context.Request.RequestUri.Query);
       var recipientType = query.Get("recipientType");
       var signatureType = query.Get("signatureType") ?? "";
+      var embeddedRecipientType = query.Get("embeddedRecipientType") ?? "";
 
       response["name"] = "dynamicSchema";
       response["title"] = "dynamicSchema";
@@ -447,6 +448,26 @@ public class Script : ScriptBase
         ["type"] = "object",
         ["properties"] = new JObject()
       };
+
+      if(embeddedRecipientType.Equals("Hybrid captive", StringComparison.OrdinalIgnoreCase))
+      {
+        response["schema"]["properties"]["embeddedRecipientStartURL"] = new JObject
+        {
+          ["type"] = "string",
+          ["x-ms-summary"] = "* Embedded recipient start URL",
+          ["default"] = "SIGN_AT_DOCUSIGN"
+        };
+      }
+
+      if(embeddedRecipientType.Equals("Remote", StringComparison.OrdinalIgnoreCase))
+      {
+        response["schema"]["properties"]["embeddedRecipientStartURL"] = new JObject
+        {
+          ["type"] = "string",
+          ["x-ms-summary"] = "* Embedded recipient start URL",
+          ["description"] = "Embedded recipient start URL",
+        };
+      }
 
       if (signatureType.Equals("UniversalSignaturePen_OpenTrust_Hash_TSP", StringComparison.OrdinalIgnoreCase))
       {
@@ -1243,6 +1264,11 @@ public class Script : ScriptBase
     AddCoreRecipientParams(signers, body);
     AddParamsForSelectedRecipientType(signers, body);
 
+    if (!string.IsNullOrEmpty(query.Get("embeddedRecipientType")))
+    {
+      AddParamsForEmbeddedRecipientType(signers, body);
+    }
+
     if (!string.IsNullOrEmpty(query.Get("signatureType")))
     {
       AddParamsForSelectedSignatureType(signers, body);
@@ -1540,6 +1566,17 @@ public class Script : ScriptBase
     {
       signers[0]["name"] = body["name"];
       signers[0]["email"] = body["email"];
+    }
+  }
+
+  private void AddParamsForEmbeddedRecipientType(JArray signers, JObject body)
+  {
+    var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
+    var embeddedRecipientType = query.Get("embeddedRecipientType");
+
+    if (embeddedRecipientType.Equals("remote"))
+    {
+      signers[0]["embeddedRecipientStartURL"] = body["embeddedRecipientStartURL"];
     }
   }
 


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


