### PR TITLE
Flow-519: Void envelope custom action

### DIFF
--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -553,6 +553,72 @@
         "x-ms-visibility": "advanced"
       }
     },
+    "/accounts/{accountId}/envelopes/{envelopeId}/voidEnvelope": {
+      "put": {
+        "summary": "Void the envelope",
+        "description": "Void the envelope.",
+        "operationId": "VoidEnvelope",
+        "x-ms-no-generic-test": true,
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "Account id",
+            "required": true,
+            "x-ms-summary": "Account",
+            "x-ms-test-value": "insert account id",
+            "x-ms-dynamic-values": {
+              "operationId": "GetLoginAccounts",
+              "value-collection": "loginAccounts",
+              "value-path": "accountIdGuid",
+              "value-title": "name"
+            },
+            "type": "string"
+          },
+          {
+            "name": "envelopeId",
+            "in": "path",
+            "description": "Envelope id",
+            "required": true,
+            "x-ms-summary": "Envelope",
+            "x-ms-test-value": "insert envelope id",
+            "type": "string"
+          },
+          {
+            "name": "voidedReason",
+            "in": "query",
+            "description": "Voided reason",
+            "required": true,
+            "x-ms-summary": "Void reason",
+            "x-ms-test-value": "insert envelope id",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/EnvelopeVoidResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "important"
+      }
+    },
     "/accounts/{accountId}/envelopes/{envelopeId}/notification": {
       "put": {
         "summary": "Add reminders for an envelope",
@@ -5191,6 +5257,10 @@
           "x-ms-visibility": "important"
         }
       }
+    },
+    "EnvelopeVoidResponse":{
+      "type": "object",
+      "properties": {}
     },
     "SendDraftEnvelopeResponse": {
       "type": "object",

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1208,6 +1208,20 @@ public class Script : ScriptBase
     return body;
   }
 
+  private JObject EnvelopeVoidBodyTransformation(JObject body)
+  {
+    var query = HttpUtility.ParseQueryString(this.Context.Request.RequestUri.Query);
+
+    body["status"] = "Voided";
+    body["voidedReason"] = query.Get("voidedReason");
+
+    var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
+    uriBuilder.Path = uriBuilder.Path.Replace("/voidEnvelope", "");
+    this.Context.Request.RequestUri = uriBuilder.Uri;
+
+    return body;
+  }
+
   private JObject AddRecipientToEnvelopeBodyTransformation(JObject body)
   {
       var signers = body["signers"] as JArray;
@@ -1784,6 +1798,11 @@ public class Script : ScriptBase
     if ("CreateBlankEnvelope".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
     {
       await this.TransformRequestJsonBody(this.CreateBlankEnvelopeBodyTransformation).ConfigureAwait(false);
+    }
+
+    if("VoidEnvelope".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
+    {
+      await this.TransformRequestJsonBody(this.EnvelopeVoidBodyTransformation).ConfigureAwait(false);
     }
 
     if ("SendEnvelope".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


